### PR TITLE
Fix large JSON load

### DIFF
--- a/src/ngx-json-viewer/ngx-json-viewer.component.html
+++ b/src/ngx-json-viewer/ngx-json-viewer.component.html
@@ -15,7 +15,7 @@
       <span *ngIf="!segment.expanded || !isExpandable(segment)" class="segment-value">{{ segment.description }}</span>
     </section>
     <section *ngIf="segment.expanded && isExpandable(segment)" class="children">
-      <ngx-json-viewer [json]="segment.value"></ngx-json-viewer>
+      <ngx-json-viewer [json]="segment.value" [expanded]="expanded"></ngx-json-viewer>
     </section>
   </section>
 </section>


### PR DESCRIPTION
Fixes issue https://github.com/hivivo/ngx-json-viewer/issues/13

Segments were being initialized as default  to `expanded=true`. If `[expanded]="false"` is passed into `ngx-json-viewer`, the parent viewer is collapsed, but all of the child segments are defaulted to `expanded=true.`

That makes for some very slow load times when expanding a large Json.

This pull request just passes the same input expanded value from the parent down through the child segments. If no value is passed to the parent, segments will default to expanded state as usual.