### PR TITLE
Add new feature: Possibility to set maximal depth of expanded items

### DIFF
--- a/src/ngx-json-viewer/ngx-json-viewer.component.html
+++ b/src/ngx-json-viewer/ngx-json-viewer.component.html
@@ -15,7 +15,7 @@
       <span *ngIf="!segment.expanded || !isExpandable(segment)" class="segment-value">{{ segment.description }}</span>
     </section>
     <section *ngIf="segment.expanded && isExpandable(segment)" class="children">
-      <ngx-json-viewer [json]="segment.value" [expanded]="expanded"></ngx-json-viewer>
+      <ngx-json-viewer [json]="segment.value" [depth]="depth" [visibleDepth]="visibleDepth" [expanded]="expanded"></ngx-json-viewer>
     </section>
   </section>
 </section>

--- a/src/ngx-json-viewer/ngx-json-viewer.component.ts
+++ b/src/ngx-json-viewer/ngx-json-viewer.component.ts
@@ -14,6 +14,7 @@ export interface Segment {
   styleUrls: ['./ngx-json-viewer.component.scss']
 })
 export class NgxJsonViewerComponent implements OnChanges {
+
   @Input() json: any;
   @Input() expanded = true;
   @Input() visibleDepth = -1;
@@ -37,9 +38,7 @@ export class NgxJsonViewerComponent implements OnChanges {
         this.segments.push(this.parseKeyValue(key, this.json[key]));
       });
     } else {
-      this.segments.push(
-        this.parseKeyValue(`(${typeof this.json})`, this.json)
-      );
+      this.segments.push(this.parseKeyValue(`(${typeof this.json})`, this.json));
     }
   }
 
@@ -92,11 +91,7 @@ export class NgxJsonViewerComponent implements OnChanges {
           segment.description = 'null';
         } else if (Array.isArray(segment.value)) {
           segment.type = 'array';
-          segment.description =
-            'Array[' +
-            segment.value.length +
-            '] ' +
-            JSON.stringify(segment.value);
+          segment.description = 'Array[' + segment.value.length + '] ' + JSON.stringify(segment.value);
         } else if (segment.value instanceof Date) {
           segment.type = 'date';
         } else {

--- a/src/ngx-json-viewer/ngx-json-viewer.component.ts
+++ b/src/ngx-json-viewer/ngx-json-viewer.component.ts
@@ -14,9 +14,10 @@ export interface Segment {
   styleUrls: ['./ngx-json-viewer.component.scss']
 })
 export class NgxJsonViewerComponent implements OnChanges {
-
   @Input() json: any;
   @Input() expanded = true;
+  @Input() visibleDepth = -1;
+  @Input() depth = -1;
   /**
    * @deprecated It will be always true and deleted in version 3.0.0
    */
@@ -29,12 +30,16 @@ export class NgxJsonViewerComponent implements OnChanges {
       this.segments = [];
     }
 
+    this.depth++;
+
     if (typeof this.json === 'object') {
-      Object.keys(this.json).forEach( key => {
+      Object.keys(this.json).forEach(key => {
         this.segments.push(this.parseKeyValue(key, this.json[key]));
       });
     } else {
-      this.segments.push(this.parseKeyValue(`(${typeof this.json})`, this.json));
+      this.segments.push(
+        this.parseKeyValue(`(${typeof this.json})`, this.json)
+      );
     }
   }
 
@@ -54,7 +59,7 @@ export class NgxJsonViewerComponent implements OnChanges {
       value: value,
       type: undefined,
       description: '' + value,
-      expanded: this.expanded
+      expanded: this.isExpanded()
     };
 
     switch (typeof segment.value) {
@@ -87,7 +92,11 @@ export class NgxJsonViewerComponent implements OnChanges {
           segment.description = 'null';
         } else if (Array.isArray(segment.value)) {
           segment.type = 'array';
-          segment.description = 'Array[' + segment.value.length + '] ' + JSON.stringify(segment.value);
+          segment.description =
+            'Array[' +
+            segment.value.length +
+            '] ' +
+            JSON.stringify(segment.value);
         } else if (segment.value instanceof Date) {
           segment.type = 'date';
         } else {
@@ -99,5 +108,12 @@ export class NgxJsonViewerComponent implements OnChanges {
     }
 
     return segment;
+  }
+
+  private isExpanded(): boolean {
+    return (
+      this.expanded &&
+      !(this.visibleDepth > -1 && this.depth >= this.visibleDepth)
+    );
   }
 }


### PR DESCRIPTION
Newly added input visibleDepth controlls maximal depth of items that will be expanded when rendered.

If extanded input is set to false, this input is ignored. If visibleDepth is set to 0, it acts like extanded is set to false – nothing is expanded by default.

Demo at [StackBlitz](https://stackblitz.com/edit/ngx-json-viewer-c7i3uu).