### PR TITLE
Fix increase one `_currentDepth` in data update

### DIFF
--- a/src/ngx-json-viewer/ngx-json-viewer.component.html
+++ b/src/ngx-json-viewer/ngx-json-viewer.component.html
@@ -15,7 +15,7 @@
       <span *ngIf="!segment.expanded || !isExpandable(segment)" class="segment-value">{{ segment.description }}</span>
     </section>
     <section *ngIf="segment.expanded && isExpandable(segment)" class="children">
-      <ngx-json-viewer [json]="segment.value" [expanded]="expanded" [depth]="depth" [_currentDepth]="_currentDepth"></ngx-json-viewer>
+      <ngx-json-viewer [json]="segment.value" [expanded]="expanded" [depth]="depth" [_currentDepth]="_currentDepth+1"></ngx-json-viewer>
     </section>
   </section>
 </section>

--- a/src/ngx-json-viewer/ngx-json-viewer.component.ts
+++ b/src/ngx-json-viewer/ngx-json-viewer.component.ts
@@ -19,7 +19,7 @@ export class NgxJsonViewerComponent implements OnChanges {
   @Input() expanded = true;
   @Input() depth = -1;
 
-  @Input() _currentDepth = -1;
+  @Input() _currentDepth = 0;
 
   segments: Segment[] = [];
 
@@ -28,8 +28,6 @@ export class NgxJsonViewerComponent implements OnChanges {
 
     // remove cycles
     this.json = this.decycle(this.json);
-
-    this._currentDepth++;
 
     if (typeof this.json === 'object') {
       Object.keys(this.json).forEach(key => {


### PR DESCRIPTION
Originally, `_currentDepth++` is in `ngOnChanges()` as initialization,
which means, when instantiate a child node, init as its `_currentDepth++`.
However, it brings a bug: when user update data in the top parent node,
`_currentDepth` will be added one unintented, the view will looks like
depth get minus one. 

[bug video demo](https://drive.google.com/file/d/1KFnMcuHmbSEzFUGKraAvAmPYTtVHodPL/view?usp=sharing)