### PR TITLE
Remove the useless "main" entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 JSON formatter and viewer for Angular
 
-Live demo: https://stackblitz.com/edit/ngx-json-viewer
+Live demo:
+- Angular 14: https://stackblitz.com/edit/angular-14-ngx-json-viewer
+- Angular 5: https://stackblitz.com/edit/ngx-json-viewer
 
 ## Install
 ```bash

--- a/example/angular.json
+++ b/example/angular.json
@@ -97,5 +97,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "url": "https://github.com/hivivo/ngx-json-viewer/issues"
   },
   "homepage": "https://github.com/hivivo/ngx-json-viewer#readme",
-  "main": "index.ts",
   "scripts": {
     "build": "ng-packagr -p ng-package.json",
     "release": "yarn build && yarn publish ./dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-json-viewer",
-  "version": "3.2.0",
+  "version": "3.2.1-alpha.0",
   "description": "JSON formatter / viewer for Angular",
   "keywords": [
     "angular",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-json-viewer",
-  "version": "3.2.1-alpha.0",
+  "version": "3.2.1",
   "description": "JSON formatter / viewer for Angular",
   "keywords": [
     "angular",


### PR DESCRIPTION
it causes some trouble like:

```
Error in src/app/app.module.ts
The entrypoint for 'ngx-json-viewer' could not successfully be resolved. The file '/turbo_modules/ngx-json-viewer@3.1.0/index.ts' does not exist. Please log an issue with the package author or check for an updated version of the package.
```